### PR TITLE
Fixing bug for vite host--expose

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server:{
+    host:true,
+    strictPort:true,
+    port:5173
+  }
 })


### PR DESCRIPTION
Before might have the problem of frontend not able to start vite when docker compose. It is fixed with setup a strictport in vite.config.js